### PR TITLE
Add generate_user_xml function with full XML fields and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .env
-.venv
+venv/
+__pycache__/
+*.pyc

--- a/scripts/xml_utils.py
+++ b/scripts/xml_utils.py
@@ -1,0 +1,21 @@
+def generate_user_xml(user):
+    xml = "<User>"
+    xml += f"<user_login>{user.get('user_login', '')}</user_login>"
+    xml += f"<user_pass>{user.get('user_pass', '')}</user_pass>"
+    xml += f"<user_email>{user.get('user_email', '')}</user_email>"
+    xml += f"<user_registered>{user.get('user_registered', '')}</user_registered>"
+
+    xml += f"<first_name>{user.get('first_name', '')}</first_name>"
+    xml += f"<last_name>{user.get('last_name', '')}</last_name>"
+    xml += f"<phone_number>{user.get('phone_number', '')}</phone_number>"
+
+    xml += f"<business_name>{user.get('business_name', '')}</business_name>"
+    xml += f"<business_email>{user.get('business_email', '')}</business_email>"
+    xml += f"<real_address>{user.get('real_address', '')}</real_address>"
+    xml += f"<btw_number>{user.get('btw_number', '')}</btw_number>"
+    xml += f"<facturation_address>{user.get('facturation_address', '')}</facturation_address>"
+
+    xml += f"<action_type>{user.get('action_type', '')}</action_type>"
+    xml += f"<time_of_action>{user.get('time_of_action', '')}</time_of_action>"
+    xml += "</User>"
+    return xml

--- a/tests/test_xml_utils.py
+++ b/tests/test_xml_utils.py
@@ -1,0 +1,26 @@
+from scripts.xml_utils import generate_user_xml
+
+def test_generate_user_xml_contains_all_fields():
+    user = {
+        "user_login": "weiam123",
+        "user_pass": "hashedpassword",
+        "user_email": "weiam@example.com",
+        "user_registered": "2025-05-16T12:00:00",
+        "first_name": "Weiam",
+        "last_name": "Almahnash",
+        "phone_number": "+32470123456",
+        "business_name": "MyCompany",
+        "business_email": "business@example.com",
+        "real_address": "Main Street 1",
+        "btw_number": "BE123456789",
+        "facturation_address": "Invoice Street 5",
+        "action_type": "create",
+        "time_of_action": "2025-05-16T12:00:00"
+    }
+
+    xml_output = generate_user_xml(user)
+
+    assert "<user_login>weiam123</user_login>" in xml_output
+    assert "<user_email>weiam@example.com</user_email>" in xml_output
+    assert "<btw_number>BE123456789</btw_number>" in xml_output
+    assert "<action_type>create</action_type>" in xml_output


### PR DESCRIPTION
This commit introduces the generate_user_xml function in scripts/xml_utils.py. The function constructs a complete XML representation of user data, including fields such as login, email, business info, and action metadata. A corresponding test file (test_xml_utils.py) is also included to validate the generated XML. All tests passed successfully using pytest.