### PR TITLE
Add complete frontend logging system to Controlroom via RabbitMQ

### DIFF
--- a/wordpress/wp-content/plugins/send-controlroom-log.php
+++ b/wordpress/wp-content/plugins/send-controlroom-log.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Plugin Name: Controlroom Log Sender
+ * Description: Sends formatted XML logs to the Controlroom via RabbitMQ.
+ * Version: 1.0
+ * Author: Attendify Team
+ */
+
+function send_controlroom_log($status, $message)
+{
+    $serviceName = 'frontend';
+    $status = strtolower($status); // Make sure status is lowercase
+    $valid_statuses = ['success', 'error', 'info', 'warning'];
+    
+    if (!in_array($status, $valid_statuses)) {
+        error_log("❌ Invalid log status: $status");
+        return;
+    }
+
+    // Add timestamp to message
+    $timestamp = date('c'); // ISO 8601
+    $fullMessage = "[" . $timestamp . "] " . $message;
+
+    // Build XML string
+    $xml = "<Log>";
+    $xml .= "<ServiceName>" . htmlspecialchars($serviceName) . "</ServiceName>";
+    $xml .= "<Status>" . htmlspecialchars($status) . "</Status>";
+    $xml .= "<Message>" . htmlspecialchars($fullMessage) . "</Message>";
+    $xml .= "</Log>";
+
+    // Save to local log file for backup/debug
+    $log_dir = plugin_dir_path(__FILE__) . 'controlroom-log-debug';
+    if (!file_exists($log_dir)) {
+        mkdir($log_dir, 0755, true);
+    }
+    $log_file = $log_dir . '/log_debug.txt';
+    file_put_contents($log_file, $xml . "\n\n", FILE_APPEND);
+
+    // Load env variables
+    $dotenv_path = dirname(__DIR__, 3) . '/.env';
+    if (file_exists($dotenv_path)) {
+        $lines = file($dotenv_path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        foreach ($lines as $line) {
+            if (strpos(trim($line), '=') !== false) {
+                list($key, $value) = explode('=', trim($line), 2);
+                $_ENV[$key] = $value;
+            }
+        }
+    }
+
+    $host = $_ENV['RABBITMQ_HOST'] ?? 'localhost';
+    $port = $_ENV['RABBITMQ_PORT'] ?? 5672;
+    $user = $_ENV['RABBITMQ_USER'] ?? 'guest';
+    $pass = $_ENV['RABBITMQ_PASSWORD'] ?? 'guest';
+    $vhost = $_ENV['MQ_VHOST'] ?? '/';
+
+    $exchange = 'log_monitoring';
+    $routing_key = 'controlroom.log.event';
+
+    // Retry settings
+    $max_retries = 3;
+    $retry_delay = 1; // seconds
+
+    $success = false;
+
+    for ($attempt = 1; $attempt <= $max_retries; $attempt++) {
+        try {
+            $connection = new PhpAmqpLib\Connection\AMQPStreamConnection(
+                $host,
+                $port,
+                $user,
+                $pass,
+                $vhost
+            );
+
+            $channel = $connection->channel();
+            $channel->exchange_declare($exchange, 'direct', false, true, false);
+
+            $msg = new PhpAmqpLib\Message\AMQPMessage($xml, [
+                'delivery_mode' => 2, // persistent
+                'content_type' => 'text/xml'
+            ]);
+
+            $channel->basic_publish($msg, $exchange, $routing_key);
+
+            $channel->close();
+            $connection->close();
+            error_log("✅ Controlroom log sent: [$status] $message");
+            $success = true;
+            break;
+
+        } catch (Exception $e) {
+            error_log("⚠️ RabbitMQ error (attempt $attempt): " . $e->getMessage());
+            sleep($retry_delay);
+        }
+    }
+
+    if (!$success) {
+        error_log("❌ Failed to send Controlroom log after $max_retries attempts.");
+    }
+}
+
+send_controlroom_log('success', '🔥 Test from LOCAL setup.');
+

--- a/wordpress/wp-content/plugins/user-consumers/user-delete-consumer.php
+++ b/wordpress/wp-content/plugins/user-consumers/user-delete-consumer.php
@@ -6,6 +6,8 @@
  * Author: Mathias Mertens
  */
 
+ require_once plugin_dir_path(__FILE__) . '/../send-controlroom-log.php'; // Load the controlroom log sender function
+
 // Laad de AMQP-bibliotheek
 require_once ABSPATH . 'vendor/autoload.php';
 
@@ -106,10 +108,11 @@ function rabbitmq_user_delete_process_cron() {
             // Verwijder de gebruiker
             if (wp_delete_user($user_id, true)) {
                 error_log("Gebruiker #{$user_id} verwijderd via consumer (UUID: {$uuid} op {$timeOfAction})");
-            } else {
-                error_log("Fout bij verwijderen gebruiker #{$user_id}");
-            }
-
+                    send_controlroom_log('success', "User #{$user_id} deleted successfully (UUID: {$uuid}) at {$timeOfAction}."); // Send success log to controlroom
+} else {
+    error_log("Fout bij verwijderen gebruiker #{$user_id}"); // Log locally
+    send_controlroom_log('error', "Failed to delete user #{$user_id} (UUID: {$uuid}) at {$timeOfAction}."); // Send error log to controlroom
+}
             // Heractiveer producer-hook
             add_action('delete_user', 'handle_user_delete', 10, 1);
 

--- a/wordpress/wp-content/plugins/user-consumers/user-update-consumer.php
+++ b/wordpress/wp-content/plugins/user-consumers/user-update-consumer.php
@@ -6,6 +6,8 @@
  * Author: Mathias Mertens
  */
 
+ require_once plugin_dir_path(__FILE__) . '/../send-controlroom-log.php'; // Load the controlroom log sender function
+
 // Laad de AMQP-bibliotheek
 require_once ABSPATH . 'vendor/autoload.php';
 
@@ -106,10 +108,14 @@ function rabbitmq_user_update_process_cron() {
 
             // Voer WP‑update uit
             $result = wp_update_user($update_data);
-            if (is_wp_error($result)) {
-                error_log('Fout bij update gebruiker #' . $user_id . ': ' . $result->get_error_message());
+           if (is_wp_error($result)) {
+    $errorMessage = $result->get_error_message(); // Get error message
+    error_log("Fout bij update gebruiker #{$user_id}: " . $errorMessage); // Log locally
+    send_controlroom_log('error', "Failed to update user #{$user_id} (UUID: {$uuid}): " . $errorMessage); // Send error log
+
             } else {
                 error_log("Gebruiker #{$user_id} bijgewerkt (UUID: {$uuid} op {$timeOfAction})");
+send_controlroom_log('success', "User #{$user_id} updated successfully (UUID: {$uuid}) at {$timeOfAction}.");// Send success log
 
                 // Optionele meta
                 if (isset($xml->PhoneNumber)) {

--- a/wordpress/wp-content/themes/inspiro/functions.php
+++ b/wordpress/wp-content/themes/inspiro/functions.php
@@ -147,3 +147,24 @@ require INSPIRO_THEME_DIR . 'inc/dynamic-css/hero-header-button.php';
 require INSPIRO_THEME_DIR . 'inc/dynamic-css/main-menu.php';
 require INSPIRO_THEME_DIR . 'inc/dynamic-css/mobile-menu.php';
 
+// ✅ Log to Controlroom when user logs in successfully
+add_action('wp_login', function($user_login, $user) {
+    if (function_exists('send_controlroom_log')) {
+        send_controlroom_log('info', "User '{$user_login}' logged in successfully.");
+    }
+}, 10, 2);
+
+// ✅ Log to Controlroom when user login fails
+add_action('wp_login_failed', function($username) {
+    if (function_exists('send_controlroom_log')) {
+        send_controlroom_log('warning', "Login failed for username: {$username}");
+    }
+});
+
+// ✅ Log to Controlroom when new user registers
+add_action('user_register', function($user_id) {
+    if (function_exists('send_controlroom_log')) {
+        $user = get_userdata($user_id);
+        send_controlroom_log('info', "New user registered with email: {$user->user_email}");
+    }
+});


### PR DESCRIPTION
- Created `send-controlroom-log.php` to send logs in valid XML format using exchange `log_monitoring` and routing key `controlroom.log.event`
- Logs include: service name (frontend), status (success, error, info, warning), and message with ISO timestamp
- Implemented retry mechanism (3 attempts) and saved all logs to local file `controlroom-log-debug/log_debug.txt`
- Integrated the log sender in all three consumers (create, update, delete) with log messages for success and failure
- Added frontend-level logging (via theme functions.php) for:
  - successful user login
  - failed login attempt
  - new user registration
- Prepared Python script (`send_controlroom_log.py`) for standalone testing if needed
- Used `.env` file for RabbitMQ credentials to avoid hardcoding sensitive data